### PR TITLE
Fix workspace name indexing in NiriWindowsLauncher

### DIFF
--- a/NiriWindowsLauncher.qml
+++ b/NiriWindowsLauncher.qml
@@ -46,7 +46,7 @@ QtObject {
             let workspaceName = "";
             const workspace = NiriService.workspaces[workspaceId];
             if (workspace) {
-                workspaceName = workspace.name || `Workspace ${workspace.idx + 1}`;
+                workspaceName = workspace.name || `Workspace ${workspace.idx}`;
             }
 
             const displayName = title || appId;


### PR DESCRIPTION
This PR adjusts the count of the workspace number to fix a off-by-one bug.